### PR TITLE
Improve small-screen responsiveness

### DIFF
--- a/src/game_components/LetterButtons.component.jsx
+++ b/src/game_components/LetterButtons.component.jsx
@@ -2,9 +2,11 @@ import LBs from '../styles/LetterButtons.module.css';
 
 const LetterButtons = ({ onClick, disabled }) => {
   const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
-  const radius = 220;
-  const centerX = 250;
-  const centerY = 250;
+
+  const isSmallScreen = window.innerWidth <= 535;
+  const radius = isSmallScreen ? 130 : 220;
+  const centerX = isSmallScreen ? 150 : 250;
+  const centerY = isSmallScreen ? 150 : 250;
 
   return (
     <div className={LBs.letterButtons}>

--- a/src/styles/GAME.module.css
+++ b/src/styles/GAME.module.css
@@ -120,6 +120,22 @@
   }
   
 }
+
+@media (max-width: 535px) {
+  .App {
+    margin: 20px auto;
+    max-width: 320px;
+  }
+
+  .circleContainer {
+    width: 300px;
+    height: 300px;
+  }
+
+  .circleCenter {
+    font-size: 12px !important;
+  }
+}
   
 
 @media (max-height: 710px) {

--- a/src/styles/LetterButtons.module.css
+++ b/src/styles/LetterButtons.module.css
@@ -50,3 +50,12 @@
   opacity: 0.8;
   cursor: not-allowed;
 }
+
+@media (max-width: 535px) {
+  .letterButtons button {
+    width: 30px;
+    height: 30px;
+    line-height: 30px;
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
## Summary
- shrink letter buttons and circle for small screens
- adjust circle container and center font-size via media query
- adjust letter button size in media query
- calculate button positions based on screen width

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687658f31df483228adcd7fc0361b995