### PR TITLE
Make RoundTable scrollable

### DIFF
--- a/src/game_components/RoundTable.component.jsx
+++ b/src/game_components/RoundTable.component.jsx
@@ -2,12 +2,17 @@ import RTs from '../styles/RoundTable.module.css';
 import Rs from '../styles/Rules.module.css';
 
 const RoundTable = ({ rounds, onClose }) => {
+  const scrollNeeded = rounds.length > 10;
   return (
     <div className={Rs.rulesOverlay}>
       <div className={Rs.rulesBox}>
         <button className={Rs.closeButton} onClick={onClose}>✕</button>
         <h2>Round's Results</h2>
-        <div className={RTs.roundTableContainer}>
+        <div
+          className={`${RTs.roundTableContainer} ${
+            scrollNeeded ? RTs.scrollable : ''
+          }`}
+        >
           <table className={RTs.roundTable}>
             <thead>
               <tr>

--- a/src/styles/RoundTable.module.css
+++ b/src/styles/RoundTable.module.css
@@ -2,6 +2,11 @@
   margin-top: 2rem;
 }
 
+.scrollable {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
 .roundTable {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- add scrollable class to `RoundTable.module.css`
- apply the class in `RoundTable.component.jsx` when more than 10 rounds are present

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877af5e25fc8322973bce2c85e9622a