### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,32 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { useEffect, useState } from "react";
 import GAME from "./pages/GAME";
 import NotFound from "./pages/NotFound";
 import Header from "./page_components/Header.component";
 import Footer from "./page_components/Footer.component";
 
 function App() {
+  const [theme, setTheme] = useState(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) return stored;
+    return window.matchMedia('(prefers-color-scheme: light)').matches
+      ? 'light'
+      : 'dark';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
   return (
     <>
       <Router>
-        <Header />
+        <Header onToggleTheme={toggleTheme} theme={theme} />
 
         <Routes>
           <Route path="/" element={<GAME />} />

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,16 @@
 
   color: rgb(255, 255, 255);
   background-color: #070613;
-  
+}
+
+:root[data-theme="dark"] {
+  color: rgb(255, 255, 255);
+  background-color: #070613;
+}
+
+:root[data-theme="light"] {
+  color: #213547;
+  background-color: #f6f6ff;
 }
 
 body{
@@ -18,7 +27,7 @@ body{
 }
 
 @media (prefers-color-scheme: light) {
-  :root {
+  :root:not([data-theme]) {
     color: #213547;
     background-color: #f6f6ff;
   }

--- a/src/page_components/Header.component.jsx
+++ b/src/page_components/Header.component.jsx
@@ -1,13 +1,18 @@
 import Hs from '../styles/Header.module.css';
 
-const Header = () => {
+const Header = ({ onToggleTheme, theme }) => {
   const restart = () => {
     window.dispatchEvent(new Event('restartGame'));
   };
   return (
     <header className={Hs.header}>
       <h1>WOR(2D)UEL</h1>
-      <button className={Hs.restart} onClick={restart}>Restart</button>
+      <div className={Hs.controls}>
+        <button className={Hs.restart} onClick={restart}>Restart</button>
+        <button className={Hs.themeToggle} onClick={onToggleTheme}>
+          {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
+        </button>
+      </div>
     </header>
   );
 };

--- a/src/styles/Footer.module.css
+++ b/src/styles/Footer.module.css
@@ -82,3 +82,7 @@ What I added:
     background-color: #ebedfd !important;
   }
 }
+
+:root[data-theme="light"] footer {
+  background-color: #ebedfd !important;
+}

--- a/src/styles/GAME.module.css
+++ b/src/styles/GAME.module.css
@@ -125,6 +125,17 @@
   
 }
 
+:root[data-theme="light"] .controls button,
+:root[data-theme="light"] .results button {
+  background-color: #ffffff;
+  border: 1px solid #000000;
+}
+
+:root[data-theme="light"] .controls button:hover,
+:root[data-theme="light"] .results button:hover {
+  color: #646cff;
+}
+
 
 /* D4_T1 
 ---> */

--- a/src/styles/Header.module.css
+++ b/src/styles/Header.module.css
@@ -13,6 +13,12 @@
   transition: all 0.5s ease !important;
 }
 
+/* container for restart and theme toggle */
+.controls {
+  display: flex;
+  flex-direction: column;
+}
+
 .header h1 {
   background: linear-gradient(45deg, #3300ff, #2db4cf) !important;
   -webkit-background-clip: text !important;
@@ -33,13 +39,43 @@
   font-family: monospace !important;
 }
 
+.themeToggle {
+  padding: 5px 10px;
+  margin: 5px 15px 0 15px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background-color: #1a1a1a;
+  cursor: pointer;
+  transition: border-color 0.25s, color 0.25s;
+  font-family: monospace !important;
+}
+
 .restart:hover {
   border-color: #646cff;
-}/* 
+}
+.themeToggle:hover {
+  border-color: #646cff;
+}/*
 <--- */
 
 @media (prefers-color-scheme: light) {
   .header {
       background-color: #ebedfd !important;
   }
+}
+
+:root[data-theme="light"] .header {
+  background-color: #ebedfd !important;
+}
+
+:root[data-theme="light"] .restart,
+:root[data-theme="light"] .themeToggle {
+  background-color: #ffffff;
+  border: 1px solid #000000;
+  color: #000000;
+}
+
+:root[data-theme="light"] .restart:hover,
+:root[data-theme="light"] .themeToggle:hover {
+  color: #646cff;
 }

--- a/src/styles/Rules.module.css
+++ b/src/styles/Rules.module.css
@@ -58,3 +58,11 @@
     border: #000000 1px solid;
   }
 }
+
+:root[data-theme="light"] .rulesBox {
+  background-color: #ffffff;
+}
+
+:root[data-theme="light"] .closeButton {
+  border: #000000 1px solid;
+}


### PR DESCRIPTION
## Summary
- add theme management in `App` with localStorage persistence
- implement Dark/Light toggle in header
- style components to use `[data-theme]` attribute

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878a8d78f6c8322a6a288c63e779413