### PR TITLE
Add tests for word generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/src/game_components/dictionary.js
+++ b/src/game_components/dictionary.js
@@ -1,4 +1,4 @@
-import nounList from '../assets/valid_nouns_4-10.json';
+import nounList from '../assets/valid_nouns_4-10.json' assert { type: 'json' };
 
 // Verify if a word is valid
 export const isValidWord = async (word) => {

--- a/src/game_components/dictionary.test.js
+++ b/src/game_components/dictionary.test.js
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'assert/strict';
+import { getPossibleWords } from './dictionary.js';
+
+// Test that the function returns words starting with the prefix
+test('getPossibleWords returns words starting with prefix', async () => {
+  const prefix = 'aba';
+  const words = await getPossibleWords(prefix);
+  assert.ok(words.length > 0, 'No words returned');
+  for (const w of words) {
+    assert.ok(w.startsWith(prefix));
+  }
+});
+
+// Test that the function returns empty array when no word matches
+test('getPossibleWords returns empty array when no words match', async () => {
+  const words = await getPossibleWords('zzzz');
+  assert.deepStrictEqual(words, []);
+});


### PR DESCRIPTION
## Summary
- make dictionary JSON import Node-compatible
- add Node test script
- test `getPossibleWords` with Node's test runner

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687aa6d581d08322a42fc87dc82cfbf5